### PR TITLE
CPT-164 refactor: a proposal of the login and logout

### DIFF
--- a/packages/datasource/src/api/me/index.js
+++ b/packages/datasource/src/api/me/index.js
@@ -3,7 +3,6 @@ import client from '../client';
 export const me = () =>
   client.get('/api/me', {
     shouldDispatchApiError: ({ status }) => {
-      console.log('status', status);
       return status !== 401;
     },
   });

--- a/packages/datasource/src/api/me/index.js
+++ b/packages/datasource/src/api/me/index.js
@@ -1,3 +1,9 @@
 import client from '../client';
 
-export const me = () => client.get(`/api/me`);
+export const me = () =>
+  client.get('/api/me', {
+    shouldDispatchApiError: ({ status }) => {
+      console.log('status', status);
+      return status !== 401;
+    },
+  });

--- a/packages/mockApi/routes/me.js
+++ b/packages/mockApi/routes/me.js
@@ -9,6 +9,11 @@ const { datatype, internet, image } = faker;
 router.get('', async (req, res) => {
   await utils.wait();
 
+  // return utils.errorResp({
+  //   code: 401,
+  //   detail: 'Authentication credentials were not provided',
+  // })(req, res);
+
   utils.successResp({
     data: {
       id: datatype.number({ min: 1, max: 5 }),
@@ -53,11 +58,6 @@ router.get('', async (req, res) => {
       ],
     },
   })(req, res);
-
-  // utils.errorResp({
-  //   code: 401,
-  //   detail: 'Authentication credentials were not provided',
-  // })(req, res);
 });
 
 module.exports = router;

--- a/src/context/me.context.js
+++ b/src/context/me.context.js
@@ -2,6 +2,6 @@ import { createContext } from 'react';
 
 export const MeContext = createContext({
   meData: undefined,
-  mutate: undefined,
-  isMeValidating: undefined,
+  mutateMe: undefined,
+  isAnonymous: undefined,
 });

--- a/src/context/nav.context.js
+++ b/src/context/nav.context.js
@@ -2,5 +2,4 @@ import { createContext } from 'react';
 
 export const NavContext = createContext({
   navData: undefined,
-  login: undefined,
 });

--- a/src/layouts/core/Core.component.js
+++ b/src/layouts/core/Core.component.js
@@ -6,14 +6,14 @@ import { useRouter } from 'next/router';
 
 import * as Styled from './core.styled';
 import { MeContext, NavContext } from 'context';
-import { link as linkUtils } from 'utils';
+import { auth, link as linkUtils } from 'utils';
 
 const Core = ({ MainWrapper = Styled.Main, children, domain = 'tug.tidb.io', hasMargin, locale = 'zh' }) => {
   const router = useRouter();
   const { meData } = useContext(MeContext);
 
   const data = getData({ domain, path: router.basePath, locale, meData }).nav;
-  const { navItems: headerNavItems, userProfileNavItems, loginUrl, logoutUrl, homeUrl } = data.header;
+  const { navItems: headerNavItems, userProfileNavItems } = data.header;
   const { navItems: footerNavItems, icons: footerIcons } = data.footer;
 
   const title = 'TiDB Community';
@@ -54,8 +54,8 @@ const Core = ({ MainWrapper = Styled.Main, children, domain = 'tug.tidb.io', has
           userProfileSlot={
             <UserProfile
               onNavClick={onNavClick}
-              onLoginClick={() => doLogin()}
-              onLogoutClick={() => doLogout()}
+              onLoginClick={() => auth.login()}
+              onLogoutClick={() => auth.logout()}
               currentNav={currentNav}
               items={userProfileNavItems}
               avatarUrl={meData?.avatar_url}

--- a/src/layouts/core/Core.component.js
+++ b/src/layouts/core/Core.component.js
@@ -8,8 +8,6 @@ import * as Styled from './core.styled';
 import { MeContext, NavContext } from 'context';
 import { link as linkUtils } from 'utils';
 
-const REG_AUTH_PATH = /https?:\/\/([^/]+)\/(?:account|orgs)\//;
-
 const Core = ({ MainWrapper = Styled.Main, children, domain = 'tug.tidb.io', hasMargin, locale = 'zh' }) => {
   const router = useRouter();
   const { meData } = useContext(MeContext);
@@ -48,30 +46,8 @@ const Core = ({ MainWrapper = Styled.Main, children, domain = 'tug.tidb.io', has
     hasMargin,
   };
 
-  const doLogin = (redirectUrl) => {
-    window.open(`${loginUrl}?redirect_to=${encodeURIComponent(redirectUrl ?? window.location.href)}`, '_top');
-  };
-
-  const doLogout = (redirectUrl) => {
-    redirectUrl = redirectUrl ?? window.location.href;
-    let url;
-    // do not redirect back to needs-login pages
-    if (REG_AUTH_PATH.test(redirectUrl)) {
-      if (!/^http/.test(homeUrl)) {
-        url = `${window.location.protocol}//${window.location.hostname}${
-          window.location.port ? `:${window.location.port}` : ''
-        }${homeUrl}`;
-      } else {
-        url = homeUrl;
-      }
-    } else {
-      url = redirectUrl;
-    }
-    window.open(`${logoutUrl}?redirect_to=${encodeURIComponent(url)}`, '_top');
-  };
-
   return (
-    <NavContext.Provider value={{ navData: data, login: doLogin, logout: doLogout }}>
+    <NavContext.Provider value={{ navData: data }}>
       <Styled.Container>
         <Header
           {...headerProps}

--- a/src/pages/_app.page.js
+++ b/src/pages/_app.page.js
@@ -39,9 +39,7 @@ const App = ({ Component, pageProps, router }) => {
     const { status, statusText, data } = err;
     const errorMsg = data?.detail || statusText;
 
-    if (status === 401) {
-      // TODO: jump to login page
-    } else if ([403, 404].includes(status)) {
+    if ([403, 404].includes(status)) {
       setErrorStatus(status);
       setErrorMsg(errorMsg);
     } else {
@@ -58,7 +56,7 @@ const App = ({ Component, pageProps, router }) => {
     setErrorMsg();
   }, [router.pathname]);
 
-  const { data: meResp, mutate: mutateMe, isValidating: isMeValidating } = useSWR('me', fetcher);
+  const { data: meResp, mutate: mutateMe, error } = useSWR('me', fetcher);
   const meData = meResp?.data;
 
   if (errorStatus) return <ErrorPage statusCode={errorStatus} errorMsg={errorMsg} />;
@@ -70,7 +68,7 @@ const App = ({ Component, pageProps, router }) => {
       }}
     >
       <GlobalStyle />
-      <MeContext.Provider value={{ meData, mutateMe, isMeValidating }}>
+      <MeContext.Provider value={{ meData, mutateMe, isAnonymous: !!error }}>
         <Component {...pageProps} />
       </MeContext.Provider>
     </SWRConfig>

--- a/src/pages/account/organization/invitations/Invitations.component.js
+++ b/src/pages/account/organization/invitations/Invitations.component.js
@@ -6,13 +6,13 @@ import { utils } from '@tidb-community/ui';
 
 import * as Styled from './invitations.styled';
 import PageLoader from 'components/pageLoader';
-import { MeContext, NavContext } from 'context';
+import { MeContext } from 'context';
+import { auth } from 'utils';
 import { emptyText, okText, cancelText } from './invitations.data';
 
 const Invitations = () => {
   const router = useRouter();
-  const { meData, mutateMe, isMeValidating } = useContext(MeContext);
-  const { login } = useContext(NavContext);
+  const { meData, mutateMe, isAnonymous } = useContext(MeContext);
   const [operating, setOperating] = useState(false);
 
   useEffect(() => {
@@ -21,16 +21,12 @@ const Invitations = () => {
     }
   });
 
-  if (!meData) {
-    if (isMeValidating) {
-      return <PageLoader />;
-    } else {
-      login();
-      return null;
-    }
+  if (isAnonymous) {
+    auth.login();
+    return null;
   }
 
-  if (meData.org) {
+  if (!meData) {
     return <PageLoader />;
   }
 

--- a/src/pages/account/organization/new/content.component.js
+++ b/src/pages/account/organization/new/content.component.js
@@ -6,13 +6,13 @@ import Banner from './banner';
 import Form from './form';
 import PageLoader from 'components/pageLoader';
 import { AUDIT_STATUS } from './audit/audit.constants';
-import { MeContext, NavContext } from 'context';
+import { MeContext } from 'context';
+import { auth } from 'utils';
 import { SplitLayout } from 'layouts';
 
 const CreateOrganization = () => {
   const router = useRouter();
-  const { meData, mutateMe, isMeValidating } = useContext(MeContext);
-  const { login } = useContext(NavContext);
+  const { meData, mutateMe, isAnonymous } = useContext(MeContext);
   const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
@@ -25,13 +25,13 @@ const CreateOrganization = () => {
   const resetForm = () => setShowForm(true);
   const pushOrgHome = () => router.push(`/orgs/${meData?.org?.slug}/members`);
 
+  if (isAnonymous) {
+    auth.login();
+    return null;
+  }
+
   if (!meData) {
-    if (isMeValidating) {
-      return <PageLoader />;
-    } else {
-      login();
-      return null;
-    }
+    return <PageLoader />;
   }
 
   if (showForm) {
@@ -41,10 +41,11 @@ const CreateOrganization = () => {
         <Form onSubmit={mutateMe} />
       </SplitLayout>
     );
-  } else {
-    return (
-      <Audit status={status} rejectReason={rejectReason} onClickResetForm={resetForm} onClickOrgHome={pushOrgHome} />
-    );
   }
+
+  return (
+    <Audit status={status} rejectReason={rejectReason} onClickResetForm={resetForm} onClickOrgHome={pushOrgHome} />
+  );
 };
+
 export default CreateOrganization;

--- a/src/pages/account/organization/new/form/fields/Agreements.component.js
+++ b/src/pages/account/organization/new/form/fields/Agreements.component.js
@@ -1,14 +1,15 @@
 import React, { useContext } from 'react';
 
+import data from '../form.data';
 import { Checkbox, Form as AntForm } from 'formik-antd';
 import { Link } from '@tidb-community/ui';
-import data from '../form.data';
 import { NavContext } from 'context';
 
 const { sla, privacy, prefixText, ...agreementsProps } = data.form.agreements;
 
 const Agreements = () => {
   const { navData } = useContext(NavContext);
+
   return (
     <AntForm.Item name={agreementsProps.name} valuePropName="checked">
       <Checkbox {...agreementsProps}>

--- a/src/pages/orgs/[slug]/members/index.page.js
+++ b/src/pages/orgs/[slug]/members/index.page.js
@@ -11,9 +11,9 @@ import AddModal from './addModal';
 import Layout from 'pages/orgs/layout';
 import PageLoader from 'components/pageLoader';
 import { CommunityHead } from 'components/head';
-import { MeContext, NavContext } from 'context';
+import { MeContext } from 'context';
+import { auth, featureToggle, errors } from 'utils';
 import { columns } from './members.data';
-import { featureToggle, errors } from 'utils';
 
 export const getServerSideProps = async ({ req }) => {
   const host = process.env.VERCEL_URL || req.headers.host;
@@ -38,18 +38,17 @@ const Members = () => {
   const router = useRouter();
   const { slug } = router.query;
   const { data: membersResp, mutate: mutateMembers } = useSWR(['orgs.org.members', router.query]);
-  const { meData, isMeValidating } = useContext(MeContext);
-  const { login } = useContext(NavContext);
+  const { meData, isAnonymous } = useContext(MeContext);
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const isAdmin = utils.isAdmin(meData);
 
+  if (isAnonymous) {
+    auth.login();
+    return null;
+  }
+
   if (!meData) {
-    if (isMeValidating) {
-      return <PageLoader />;
-    } else {
-      login();
-      return null;
-    }
+    return <PageLoader />;
   }
 
   const onRoleChange = async ({ id, role }) => {

--- a/src/utils/auth.utils.js
+++ b/src/utils/auth.utils.js
@@ -1,0 +1,30 @@
+import { getData } from '@tidb-community/datasource';
+
+const loginUrl = 'https://accounts.pingcap.com/login';
+const logoutUrl = 'https://accounts.pingcap.com/logout';
+const REG_AUTH_PATH = /https?:\/\/([^/]+)\/(?:account|orgs)\//;
+
+export const login = (redirectUrl) => {
+  if (typeof window === 'undefined') return;
+  window.open(`${loginUrl}?redirect_to=${encodeURIComponent(redirectUrl ?? window.location.href)}`, '_top');
+};
+
+export const logout = (redirectUrl) => {
+  if (typeof window === 'undefined') return;
+
+  redirectUrl = redirectUrl ?? window.location.href;
+  let url;
+  // do not redirect back to needs-login pages
+  if (REG_AUTH_PATH.test(redirectUrl)) {
+    if (!/^http/.test(homeUrl)) {
+      url = `${window.location.protocol}//${window.location.hostname}${
+        window.location.port ? `:${window.location.port}` : ''
+      }${homeUrl}`;
+    } else {
+      url = homeUrl;
+    }
+  } else {
+    url = redirectUrl;
+  }
+  window.open(`${logoutUrl}?redirect_to=${encodeURIComponent(url)}`, '_top');
+};

--- a/src/utils/auth.utils.js
+++ b/src/utils/auth.utils.js
@@ -1,5 +1,4 @@
-import { getData } from '@tidb-community/datasource';
-
+const homeUrl = 'https://tidb.io/';
 const loginUrl = 'https://accounts.pingcap.com/login';
 const logoutUrl = 'https://accounts.pingcap.com/logout';
 const REG_AUTH_PATH = /https?:\/\/([^/]+)\/(?:account|orgs)\//;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,7 +22,8 @@ export async function getExcerptByTopicId(id, wordCountLimit = 70) {
   return fullExcerpt.length > wordCountLimit ? fullExcerpt.slice(0, wordCountLimit) + ' ...' : fullExcerpt;
 }
 
-export * as featureToggle from './featureToggle';
-export * as link from './link.utils';
-export * as form from './form.utils';
+export * as auth from './auth.utils';
 export * as errors from './errors.utils';
+export * as featureToggle from './featureToggle';
+export * as form from './form.utils';
+export * as link from './link.utils';


### PR DESCRIPTION
It's a proposal of refactoring the current login & logout functions. I implemented it late yesterday night, so I am afraid my refactoring didn't cover every use cases. But I think it illustrates well the motivation and thoughts of my refactoring. So I'd like to raise a PR for a POC (proof of concept) discussion.

Literally, my PR involves two things:

### 1. Make `/api/me` handler tackle with 401 unauthorised error and detect `isAnonymous` status by the 401.
Reason: It makes the code more readable and also simplifies the current redirection and page loader conditions.

### 2. Move login & logout functions out of NavContext.
Reason:
- Injecting the login and logout in CoreLayout is too late. At the time when 401 occurs from the me API handler, the CoreLayout is not even rendered. So it will cause another JS error. 
- login & logout are more like business independent methods so that we'd better to extract them into a utility lib.