### PR TITLE
chore: bump sentry lib version to 6.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4673,13 +4673,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.1.tgz",
-      "integrity": "sha512-3cDud6GWutnJqcnheIq0lPNTsUJbrRLevQ+g1YfawVXFUxfmmY2bOsGd/Mxq17LxYeBHgKTitXv3DU1bsQ+WBQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.7.0.tgz",
+      "integrity": "sha512-sZvy2fxHjHXPdlaz8Ax02BeUbdILRv6a4i9FvMHvgSBeDiAVRIS+ihBhJAqziNOqwwXYThCSPKcCYGyTTncrVw==",
       "requires": {
-        "@sentry/core": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/core": "6.7.0",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "tslib": "^1.9.3"
       }
     },
@@ -4697,58 +4697,59 @@
       }
     },
     "@sentry/core": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
-      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.0.tgz",
+      "integrity": "sha512-1TzDQIsS71a+6T1o3+NPyIgsTc37wdGh7cKZ8DRQ4bsML7MAkBV/LJeTVbXa0S9xha1v9v/oPindnHX5vBLJbg==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/minimal": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/hub": "6.7.0",
+        "@sentry/minimal": "6.7.0",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
-      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.0.tgz",
+      "integrity": "sha512-8e1IF6v8OIjuZVsolBAFoHhY0fEolsWwmZzm9k5N1wXWRbu4gpLHnCtDw47u2O9CFYr+b//bNXjmsA+DTckPkw==",
       "requires": {
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.4.1.tgz",
-      "integrity": "sha512-3kw6NcrFGXW+qlfT112EkYt7jdFX55m9yJN5eCt7Iad59YzA8ji8Pio5ohy9Pl+OfYXlKRFOvnYPpZZn80UjlQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.7.0.tgz",
+      "integrity": "sha512-sEmlbE84Ljcbu5fqmOHv5IgbYKhKBsiGzOhgLdMMchIMPAnJ2vc22jq0xaqLUO6WCmRgJZjeManYkXtImFu44g==",
       "requires": {
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
-      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.0.tgz",
+      "integrity": "sha512-q0SX2t1+6c8TSe8nI4+EsWc8+kSsKiGhoGo2tN2OTk4EXKCYEsEEDqB9iu7md5StmtmrO3UnRiYwT7JV8QGOeg==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/types": "6.4.1",
+        "@sentry/hub": "6.7.0",
+        "@sentry/types": "6.7.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/nextjs": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.4.1.tgz",
-      "integrity": "sha512-5z9Zifu5mSzolsrKsN2LeHzAsZlssfdPltJg58ekNuqCbveKAXQ4MzbF80xPHylOvmHk634oPPzbr5eLk/nG7w==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.7.0.tgz",
+      "integrity": "sha512-xdc9DSA1teXpu/RxPJ9gbrd8GqayGicgRjd3jSJlO+g4gykr0bYH2drtZjpMUM+Sy3uhnVMJHmPtGFyvJaMktQ==",
       "requires": {
-        "@sentry/core": "6.4.1",
-        "@sentry/integrations": "6.4.1",
-        "@sentry/node": "6.4.1",
-        "@sentry/react": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/core": "6.7.0",
+        "@sentry/integrations": "6.7.0",
+        "@sentry/node": "6.7.0",
+        "@sentry/react": "6.7.0",
+        "@sentry/tracing": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "@sentry/webpack-plugin": "1.15.0",
         "tslib": "^1.9.3"
       },
@@ -4764,15 +4765,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.4.1.tgz",
-      "integrity": "sha512-w4IFRA7UFZxKL9xVXmQU8eAjVMY/sr0fJcTV8Wma4uZqa1FQVX4p6xgfylLrcaA8VsolE3l9LRrP1XYxCVwvOw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.7.0.tgz",
+      "integrity": "sha512-ND29/LiaiaF4zvKaDRAtZH01clgk6eXtZQiA/aYOiStI/P4d2OfzW09rUsJVwX4h9w7mNpRKCUyGdVs4q2vipQ==",
       "requires": {
-        "@sentry/core": "6.4.1",
-        "@sentry/hub": "6.4.1",
-        "@sentry/tracing": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/core": "6.7.0",
+        "@sentry/hub": "6.7.0",
+        "@sentry/tracing": "6.7.0",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -4780,41 +4781,41 @@
       }
     },
     "@sentry/react": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.4.1.tgz",
-      "integrity": "sha512-/rbp9jFgFc+m3DWhI58uKSLQxXtIW5bKqu5eVO/9jedhLzGRGBp0eOlJ5qtZ3KtYKSyPbA4uEBY5qI0rGwipeA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.7.0.tgz",
+      "integrity": "sha512-/ZecGCBr4JFZmpQdXE4reaMSzjsVli5Qqc6vxMBF6/p7yGqtiCCL3W0IUwAemTrLcByMFW6cJL42JK70nM31yg==",
       "requires": {
-        "@sentry/browser": "6.4.1",
-        "@sentry/minimal": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/browser": "6.7.0",
+        "@sentry/minimal": "6.7.0",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/tracing": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.4.1.tgz",
-      "integrity": "sha512-EPRadE9n/wpUjx4jqP/8vXdOAZBk7vjlzRKniJgKgQUO3v03i0ui6xydaal2mvhplIyOCI2muXdGhjUO7ga4uw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.7.0.tgz",
+      "integrity": "sha512-5joTxxDB4v2J1B3CIGDj4AJKJpeGztqExQMkCrwwWgBsZ+fFfctRSCyiwYo50TU93Zt/rt0rDjj8QF4o8ZH09A==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/minimal": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/hub": "6.7.0",
+        "@sentry/minimal": "6.7.0",
+        "@sentry/types": "6.7.0",
+        "@sentry/utils": "6.7.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.0.tgz",
+      "integrity": "sha512-5pKv0yJEOnkjy3J3eiGaM1CD2+p3rXkctJa8loZH7QgY7mJgUTKpozO3YymUmGjblthlrbuhH+5wUIBnVF60Bg=="
     },
     "@sentry/utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
-      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.0.tgz",
+      "integrity": "sha512-K6s9svqOF4TT4AwvlDdiV9ZSGStSnf64s8KH1DNqwu5EZULvXvg0kbqgi6ZJTDHcchbnwHm7hLMNfuw95Aqi4Q==",
       "requires": {
-        "@sentry/types": "6.4.1",
+        "@sentry/types": "6.7.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "4.6.2",
-    "@sentry/nextjs": "6.4.1",
+    "@sentry/nextjs": "6.7.0",
     "ahooks": "2.10.4",
     "antd": "4.15.6",
     "axios": "0.21.1",

--- a/packages/accounts/package-lock.json
+++ b/packages/accounts/package-lock.json
@@ -357,84 +357,84 @@
 			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
 		},
 		"@sentry/browser": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.5.1.tgz",
-			"integrity": "sha512-iVLCdEFwsoWAzE/hNknexPQjjDpMQV7mmaq9Z1P63bD6MfhwVTx4hG4pHn8HEvC38VvCVf1wv0v/LxtoODAYXg==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.7.0.tgz",
+			"integrity": "sha512-sZvy2fxHjHXPdlaz8Ax02BeUbdILRv6a4i9FvMHvgSBeDiAVRIS+ihBhJAqziNOqwwXYThCSPKcCYGyTTncrVw==",
 			"requires": {
-				"@sentry/core": "6.5.1",
-				"@sentry/types": "6.5.1",
-				"@sentry/utils": "6.5.1",
+				"@sentry/core": "6.7.0",
+				"@sentry/types": "6.7.0",
+				"@sentry/utils": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/core": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
-			"integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.0.tgz",
+			"integrity": "sha512-1TzDQIsS71a+6T1o3+NPyIgsTc37wdGh7cKZ8DRQ4bsML7MAkBV/LJeTVbXa0S9xha1v9v/oPindnHX5vBLJbg==",
 			"requires": {
-				"@sentry/hub": "6.5.1",
-				"@sentry/minimal": "6.5.1",
-				"@sentry/types": "6.5.1",
-				"@sentry/utils": "6.5.1",
+				"@sentry/hub": "6.7.0",
+				"@sentry/minimal": "6.7.0",
+				"@sentry/types": "6.7.0",
+				"@sentry/utils": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/hub": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
-			"integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.0.tgz",
+			"integrity": "sha512-8e1IF6v8OIjuZVsolBAFoHhY0fEolsWwmZzm9k5N1wXWRbu4gpLHnCtDw47u2O9CFYr+b//bNXjmsA+DTckPkw==",
 			"requires": {
-				"@sentry/types": "6.5.1",
-				"@sentry/utils": "6.5.1",
+				"@sentry/types": "6.7.0",
+				"@sentry/utils": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/minimal": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
-			"integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.0.tgz",
+			"integrity": "sha512-q0SX2t1+6c8TSe8nI4+EsWc8+kSsKiGhoGo2tN2OTk4EXKCYEsEEDqB9iu7md5StmtmrO3UnRiYwT7JV8QGOeg==",
 			"requires": {
-				"@sentry/hub": "6.5.1",
-				"@sentry/types": "6.5.1",
+				"@sentry/hub": "6.7.0",
+				"@sentry/types": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/react": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.5.1.tgz",
-			"integrity": "sha512-YeGi7FzInhMZQxiy5fKqb7kS6W+u4NfsjzsVV3bLjJ1kiVtbpzZ2gs+ObHqW3zVE622V4nL7A4P8/CBHbcm5PA==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.7.0.tgz",
+			"integrity": "sha512-/ZecGCBr4JFZmpQdXE4reaMSzjsVli5Qqc6vxMBF6/p7yGqtiCCL3W0IUwAemTrLcByMFW6cJL42JK70nM31yg==",
 			"requires": {
-				"@sentry/browser": "6.5.1",
-				"@sentry/minimal": "6.5.1",
-				"@sentry/types": "6.5.1",
-				"@sentry/utils": "6.5.1",
+				"@sentry/browser": "6.7.0",
+				"@sentry/minimal": "6.7.0",
+				"@sentry/types": "6.7.0",
+				"@sentry/utils": "6.7.0",
 				"hoist-non-react-statics": "^3.3.2",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/tracing": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.5.1.tgz",
-			"integrity": "sha512-y1W/xFC2hAuKqSuuaovkElHY4pbli3XoXrreesg8PtO7ilX6ZbatOQbHsEsHQyoUv0F6aVA+MABOxWH2jt7tfw==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.7.0.tgz",
+			"integrity": "sha512-5joTxxDB4v2J1B3CIGDj4AJKJpeGztqExQMkCrwwWgBsZ+fFfctRSCyiwYo50TU93Zt/rt0rDjj8QF4o8ZH09A==",
 			"requires": {
-				"@sentry/hub": "6.5.1",
-				"@sentry/minimal": "6.5.1",
-				"@sentry/types": "6.5.1",
-				"@sentry/utils": "6.5.1",
+				"@sentry/hub": "6.7.0",
+				"@sentry/minimal": "6.7.0",
+				"@sentry/types": "6.7.0",
+				"@sentry/utils": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/types": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
-			"integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA=="
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.0.tgz",
+			"integrity": "sha512-5pKv0yJEOnkjy3J3eiGaM1CD2+p3rXkctJa8loZH7QgY7mJgUTKpozO3YymUmGjblthlrbuhH+5wUIBnVF60Bg=="
 		},
 		"@sentry/utils": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
-			"integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.0.tgz",
+			"integrity": "sha512-K6s9svqOF4TT4AwvlDdiV9ZSGStSnf64s8KH1DNqwu5EZULvXvg0kbqgi6ZJTDHcchbnwHm7hLMNfuw95Aqi4Q==",
 			"requires": {
-				"@sentry/types": "6.5.1",
+				"@sentry/types": "6.7.0",
 				"tslib": "^1.9.3"
 			}
 		},

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -9,8 +9,8 @@
     "start": "vite"
   },
   "dependencies": {
-    "@sentry/react": "6.5.1",
-    "@sentry/tracing": "6.5.1",
+    "@sentry/react": "6.7.0",
+    "@sentry/tracing": "6.7.0",
     "@tidb-community/common": "*",
     "@tidb-community/ui": "*",
     "antd": "4.15.6",


### PR DESCRIPTION
There was an outdated version alert from sentry website.