### PR TITLE
CP-162: add fields to cms for activities calendar

### DIFF
--- a/packages/strapi/api/tidbio-activitiespage-activities/models/tidbio-activitiespage-activities.settings.json
+++ b/packages/strapi/api/tidbio-activitiespage-activities/models/tidbio-activitiespage-activities.settings.json
@@ -21,6 +21,12 @@
     "date": {
       "type": "date"
     },
+    "startDate": {
+      "type": "date"
+    },
+    "endDate": {
+      "type": "date"
+    },
     "image": {
       "collection": "file",
       "via": "related",


### PR DESCRIPTION
In the future, we may add some activities to the activities content type, and these activities will be held for more than one day, so I add the startDate and endDate fields to the CMS.
For the preview environment available, we usually merge the latest CMS modification into the main branch first and then merge the front-end modification